### PR TITLE
Fix "TypeError: res.status is not a function" which was breaking Express API

### DIFF
--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,4 +1,4 @@
-const errorHandler = (err, req, res) => {
+const errorHandler = (err, req, res, next) => {
   res.status(err.code || 500).json({
     msg: err.msg || 'An unknown error occurred!',
   });


### PR DESCRIPTION
Fixed the issue where Express was breaking due to incomplete arguments passed to errorHandler